### PR TITLE
Ot240 93: Miembros a página de contacto

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -3,7 +3,7 @@ import style from './styles/Footer.module.scss';
 import LogoFooter from '../LogoFooter/LogoFooter';
 import Links from '../Links/Links';
 import RedesIcons from '../RedesIcons/RedesIcons';
-import fetchApi from '../FetchApi/FetchApi';
+import fetchApi from '../../axios/axios';
 
 const Footer = () => {
   const [navigationItems, setNavigationItems] = useState([]);

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -32,7 +32,6 @@ const Header = () => {
           { text: 'Miembros', route: '/backoffice/miembros' },
         ])
       : setNavigationItems([
-          { text: 'Inicio', route: '/' },
           { text: 'Nosotros', route: '/nosotros' },
           { text: 'Novedades', route: '/novedades' },
           { text: 'Testimonios', route: '/testimonios' },

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import style from './styles/Header.module.scss';
 import logo from './assets/LOGO-SOMOS-MAS.png';
 import Hamburger from '../Hamburger/Hamburger';
@@ -8,6 +8,7 @@ import Buttons from '../Buttons/Buttons';
 
 const Header = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const [menuIsOpen, setMenuIsOpen] = useState(false);
 
   const [navigationItems, setNavigationItems] = useState([]);
@@ -20,6 +21,7 @@ const Header = () => {
     //obtener links desde endpoint de datos públicos o de algun store de redux y que se cargue al principio
     location.pathname.includes('backoffice')
       ? setNavigationItems([
+          { text: 'Novedades', route: '/backoffice/novedades' },
           { text: 'Novedades', route: '/backoffice/novedades' },
           { text: 'Actividades', route: '/backoffice/actividades' },
           { text: 'Categorias', route: '/backoffice/categorias' },
@@ -43,7 +45,7 @@ const Header = () => {
     <>
       <header className={style.header}>
         <div className={style.topBar}>
-          <img src={logo} alt='somos_mas_logo' />
+          <img src={logo} alt='somos_mas_logo' onClick={() => navigate('/')} />
           <div className={` ${style.topLinks} `}>
             <Links navigationItems={navigationItems} />
             <Buttons />

--- a/src/components/Header/styles/Header.module.scss
+++ b/src/components/Header/styles/Header.module.scss
@@ -17,6 +17,7 @@
       z-index: 1;
       width: 150px;
       margin-left: 30px;
+      cursor: pointer;
     }
 
     .topLinks {

--- a/src/components/NewsSlider/NewsSlider.jsx
+++ b/src/components/NewsSlider/NewsSlider.jsx
@@ -31,7 +31,7 @@ const NewsSlider = ({ limit }) => {
 
   return (
     <article id='slider'>
-      {!loading && news.length && (
+      {!loading && news.length ? (
         <Carousel infiniteLoop={true} showStatus={false} showThumbs={false} transitionTime={500}>
           {news.slice(0, limit).map(({ image, name }, i) => (
             <figure key={i}>
@@ -44,6 +44,8 @@ const NewsSlider = ({ limit }) => {
             </figure>
           ))}
         </Carousel>
+      ) : (
+        ''
       )}
     </article>
   );

--- a/src/pages/Public/Members/Members.jsx
+++ b/src/pages/Public/Members/Members.jsx
@@ -1,48 +1,73 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation, Link } from 'react-router-dom';
+
 import MembersBanners from './MembersBanner/MembersBanner';
 import MembersList from './MembersList/MembersList';
 import style from './styles/Members.module.scss';
-import memberMock from '../../../members.mock';
+import fetchApi from '../../../axios/axios';
 
 const Members = ({ quantity }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [members, setMembers] = useState([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setMembers(memberMock);
+    let isMounted = true;
+    const getMembers = async () => {
+      try {
+        const { data } = await fetchApi({ method: 'get', url: '/members' });
+        isMounted && setMembers(data.members);
+      } catch (err) {
+        isMounted && setError(err.message);
+      } finally {
+        isMounted && setLoading(false);
+      }
+    };
+
+    getMembers();
+
+    return () => (isMounted = false);
   }, []);
 
-  const sendMember = (memb) => {
+  const selectRandomMember = (memb) => {
     const random = Math.floor(Math.random() * memb.length);
     return memb[random];
   };
 
-  // !location.pathname.includes('testimonios')
-  console.log(members);
   return (
     <div className={style.container}>
-      <div
-        className={
-          !location.pathname.includes('nosotros')
-            ? `${style.header}`
-            : `${style.header} ${style.headerPage}`
-        }>
-        <h2
-          className={
-            location.pathname.includes('nosotros')
-              ? `${style.title} ${style.titleCentered}`
-              : `${style.title}`
-          }>
-          {location.pathname.includes('nosotros') ? '¡Nuestro Staff!' : 'Nuestro Staff'}
-        </h2>
-        {location.pathname.includes('nosotros') && members.length > 0 && (
-          <MembersBanners member={sendMember(members)} />
-        )}
-        {!location.pathname.includes('nosotros') && <Link to='/nosotros'>{`Ver mas >`}</Link>}
-      </div>
-      <MembersList quantity={quantity} members={members} />
+      {!loading ? (
+        members.length ? (
+          <>
+            <div
+              className={
+                !location.pathname.includes('nosotros')
+                  ? `${style.header}`
+                  : `${style.header} ${style.headerPage}`
+              }>
+              <h2
+                className={
+                  location.pathname.includes('nosotros')
+                    ? `${style.title} ${style.titleCentered}`
+                    : `${style.title}`
+                }>
+                {location.pathname.includes('nosotros') ? '¡Nuestro Staff!' : 'Nuestro Staff'}
+              </h2>
+              {location.pathname.includes('nosotros') && members.length > 0 && (
+                <MembersBanners member={selectRandomMember(members)} />
+              )}
+              {!location.pathname.includes('nosotros') && <Link to='/nosotros'>{`Ver mas >`}</Link>}
+            </div>
+            <MembersList quantity={quantity} members={members} />
+          </>
+        ) : (
+          <h1>Todavía no hay miembros cargados a la plataforma</h1>
+        )
+      ) : (
+        <p>Cargando..</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
#  Summary 
- Implement actual databse to display members contents at `/nosotros`
- Use ong logo to navigate to home instead of dedicated "home" button (save nav space)
- Modify `<NewsSlider/>` to show nothing if no news to display (bug: was showing a "0")
